### PR TITLE
Verify token middleware added

### DIFF
--- a/backend/src/constants/response-message.constant.ts
+++ b/backend/src/constants/response-message.constant.ts
@@ -12,7 +12,8 @@ export const HttpResponse = {
   USER_CREATION_SUCCESS: "User created successfully",
   UNEXPECTED_KEY_FOUND: "Unexpected key found",
   INVALID_EMAIL: "Invalid email address",
-  RESET_PASS_LINK : "Link for resetting password is sended to email",
-  TOKEN_EXPIRED : "Token not valid or expired !",
-  PASSWORD_CHANGE_SUCCESS : "Password changed successfully !",
+  RESET_PASS_LINK: "Link for resetting password is sended to email",
+  TOKEN_EXPIRED: "Token not valid or expired!",
+  PASSWORD_CHANGE_SUCCESS: "Password changed successfully!",
+  UNAUTHORIZED: "Unauthorized access!",
 };

--- a/backend/src/middlewares/verify-token.middleware.ts
+++ b/backend/src/middlewares/verify-token.middleware.ts
@@ -1,0 +1,54 @@
+import { Request, Response, NextFunction } from "express";
+import { verifyAccessToken } from "@/utils/jwt.util";
+import { HttpResponse } from "@/constants/response-message.constant";
+import { HttpStatus } from "@/constants/status.constant";
+
+export default function (
+  userLevel: "user" | "admin" | "moderator"
+): (req: Request, res: Response, next: NextFunction) => void | Response {
+  return (req: Request, res: Response, next: NextFunction): void | Response => {
+    try {
+      const authHeader = req.headers.authorization;
+
+      if (!authHeader || !authHeader.startsWith("Bearer")) {
+        return res
+          .status(HttpStatus.UNAUTHORIZED)
+          .json({ error: HttpResponse.NO_TOKEN });
+      }
+
+      const token = authHeader.split(" ")[1];
+      if (!token) {
+        return res
+          .status(HttpStatus.UNAUTHORIZED)
+          .json({ error: HttpResponse.NO_TOKEN });
+      }
+
+      const payload = verifyAccessToken(token) as {
+        id: string;
+        email: string;
+        role: "user" | "admin" | "moderator";
+      };
+
+      if (payload.role !== userLevel) {
+        return res
+          .status(HttpStatus.UNAUTHORIZED)
+          .json({ error: HttpResponse.UNAUTHORIZED });
+      }
+
+      req.headers["x-user-payload"] = JSON.stringify(payload);
+      next();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      if (err.name === "TokenExpiredError") {
+        return res
+          .status(HttpStatus.FORBIDDEN)
+          .json({ error: HttpResponse.TOKEN_EXPIRED });
+      } else {
+        return res
+          .status(HttpStatus.UNAUTHORIZED)
+          .json({ error: HttpResponse.TOKEN_EXPIRED });
+      }
+    }
+  };
+}

--- a/backend/src/utils/validate-env.util.ts
+++ b/backend/src/utils/validate-env.util.ts
@@ -28,4 +28,7 @@ export function validateEnv() {
   if (!env.CLIENT_ORIGIN) {
     throw new Error("CLIENT_ORIGIN is not found in the env");
   }
+  if (!env.RESET_PASS_URL) {
+    throw new Error("RESET_PASS_URL is not found in the env");
+  }
 }


### PR DESCRIPTION
The logic for validating access token added with proper response status code making refresh token API call more convenient.
The RESET_PASS_URL ENV variable didn't had validation, that was added as well