### PR TITLE
feat: add image crop in profile

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-easy-crop": "^5.4.1",
     "react-hook-form": "^7.54.2",
     "react-icons": "^5.5.0",
     "react-markdown": "^10.0.1",

--- a/frontend/src/components/user/editProfile/ImageModal.tsx
+++ b/frontend/src/components/user/editProfile/ImageModal.tsx
@@ -1,0 +1,52 @@
+import { FC } from 'react'
+import Cropper from 'react-easy-crop';
+
+interface ImageModalProps {
+    image: string | null;
+    crop: { x: number; y: number };
+    setCrop: React.Dispatch<React.SetStateAction<{ x: number; y: number }>>;
+    zoom: number;
+    setZoom: React.Dispatch<React.SetStateAction<number>>;
+    onCropComplete: (croppedArea: any, croppedAreaPixels: { width: number; height: number; x: number; y: number }) => void;
+    handleSave: () => void;
+    closeModal: () => void;
+  }
+
+const ImageModal:FC<ImageModalProps>= ({ 
+    image, 
+    crop, 
+    setCrop, 
+    zoom, 
+    setZoom, 
+    onCropComplete, 
+    handleSave, 
+    closeModal
+ }) => {
+  return (
+    <div className="fixed inset-0 bg-black flex flex-col gap-5
+        items-center justify-center z-50">
+      <div className="bg-white p-5 rounded-lg shadow-lg w-96 h-96 relative">
+        <Cropper
+          image={image ?? undefined}
+          crop={crop}
+          zoom={zoom}
+          aspect={1}
+          onCropChange={setCrop}
+          onZoomChange={setZoom}
+          onCropComplete={onCropComplete}
+        />
+        
+      </div>
+      <div className="flex justify-between gap-7">
+        <button onClick={() => handleSave()} className="bg-blue-800 text-white hover:bg-neutral-300 dark:bg-blue-800 
+                    hover:text-gray-700 dark:text-gray-200 rounded-full p-1 dark:hover:bg-gray-800
+                     px-4 py-2 cursor-pointer">Save</button>
+        <button onClick={() => closeModal()} className="bg-red-800 text-white hover:bg-neutral-300 dark:bg-red-800 
+                    hover:text-gray-700 dark:text-gray-200 rounded-full p-1 dark:hover:bg-gray-800 
+                     px-4 py-2 cursor-pointer">Cancel</button>
+      </div>
+    </div>
+  )
+}
+
+export default ImageModal;

--- a/frontend/src/components/user/editProfile/ImageModal.tsx
+++ b/frontend/src/components/user/editProfile/ImageModal.tsx
@@ -7,7 +7,8 @@ interface ImageModalProps {
     setCrop: React.Dispatch<React.SetStateAction<{ x: number; y: number }>>;
     zoom: number;
     setZoom: React.Dispatch<React.SetStateAction<number>>;
-    onCropComplete: (croppedArea: any, croppedAreaPixels: { width: number; height: number; x: number; y: number }) => void;
+    onCropComplete: (croppedArea: { x: number; y: number; width: number; height: number }, 
+      croppedAreaPixels: { width: number; height: number; x: number; y: number }) => void;
     handleSave: () => void;
     closeModal: () => void;
   }

--- a/frontend/src/components/user/editProfile/ImageModal.tsx
+++ b/frontend/src/components/user/editProfile/ImageModal.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import Cropper from 'react-easy-crop';
+import Cropper, { Area } from 'react-easy-crop';
 
 interface ImageModalProps {
     image: string | null;
@@ -7,8 +7,8 @@ interface ImageModalProps {
     setCrop: React.Dispatch<React.SetStateAction<{ x: number; y: number }>>;
     zoom: number;
     setZoom: React.Dispatch<React.SetStateAction<number>>;
-    onCropComplete: (croppedArea: { x: number; y: number; width: number; height: number }, 
-      croppedAreaPixels: { width: number; height: number; x: number; y: number }) => void;
+    onCropComplete: (croppedArea: Area, 
+      croppedAreaPixels: Area) => void;
     handleSave: () => void;
     closeModal: () => void;
   }

--- a/frontend/src/components/user/editProfile/PictureInput.tsx
+++ b/frontend/src/components/user/editProfile/PictureInput.tsx
@@ -4,6 +4,7 @@ import { X } from "lucide-react";
 import { FC, useState, useRef, useCallback } from "react";
 import ImageModal from "./ImageModal";
 import { getCroppedImg } from "./cropImage";
+import { Area } from "react-easy-crop";
 
 const PictureInput: FC = () => {
   const [image, setImage] = useState<string | null>(null);
@@ -12,12 +13,7 @@ const PictureInput: FC = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
-  const [croppedAreaPixels, setCroppedAreaPixels] = useState<{
-    width: number;
-    height: number;
-    x: number;
-    y: number;
-  }| null>(null);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
 
   // Handle file selection
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -45,8 +41,8 @@ const PictureInput: FC = () => {
     setCroppedImage(null);
   }
 
-  const onCropComplete = useCallback((_val: any, 
-    croppedAreaPixels: { width: number; height: number; x: number; y: number }) => {
+  const onCropComplete = useCallback((_val: Area, 
+    croppedAreaPixels: Area) => {
    setCroppedAreaPixels(croppedAreaPixels);
   }, []);
 

--- a/frontend/src/components/user/editProfile/cropImage.ts
+++ b/frontend/src/components/user/editProfile/cropImage.ts
@@ -1,6 +1,8 @@
+import { Area } from "react-easy-crop";
+
 export const getCroppedImg = async (
     imageSrc: String, 
-    croppedAreaPixels: { width: number; height: number; x: number; y: number; }
+    croppedAreaPixels: Area
     ):Promise<string> => {
   const image = await createImage(imageSrc as string);
   const canvas = document.createElement("canvas");

--- a/frontend/src/components/user/editProfile/cropImage.ts
+++ b/frontend/src/components/user/editProfile/cropImage.ts
@@ -1,7 +1,7 @@
 import { Area } from "react-easy-crop";
 
 export const getCroppedImg = async (
-    imageSrc: String, 
+    imageSrc: string, 
     croppedAreaPixels: Area
     ):Promise<string> => {
   const image = await createImage(imageSrc as string);

--- a/frontend/src/components/user/editProfile/cropImage.ts
+++ b/frontend/src/components/user/editProfile/cropImage.ts
@@ -1,0 +1,47 @@
+export const getCroppedImg = async (
+    imageSrc: String, 
+    croppedAreaPixels: { width: number; height: number; x: number; y: number; }
+    ):Promise<string> => {
+  const image = await createImage(imageSrc as string);
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+
+  if (!ctx) throw new Error("Could not get canvas context");
+
+  canvas.width = croppedAreaPixels.width;
+  canvas.height = croppedAreaPixels.height;
+
+  ctx.drawImage(
+    image,
+    croppedAreaPixels.x,
+    croppedAreaPixels.y,
+    croppedAreaPixels.width,
+    croppedAreaPixels.height,
+    0,
+    0,
+    croppedAreaPixels.width,
+    croppedAreaPixels.height
+  );
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(URL.createObjectURL(blob));
+      } else {
+        reject(new Error("Canvas toBlob failed"));
+      }
+    }, "image/jpeg");
+  });
+};
+
+
+export function createImage(url: string): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.crossOrigin = "anonymous"; 
+      img.src = url;
+  
+      img.onload = () => resolve(img);
+      img.onerror = (error) => reject(error);
+    });
+  }

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "next-themes": "^0.4.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-easy-crop": "^5.4.1",
         "react-hook-form": "^7.54.2",
         "react-icons": "^5.5.0",
         "react-markdown": "^10.0.1",
@@ -6763,6 +6764,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7139,6 +7146,20 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.4.1.tgz",
+      "integrity": "sha512-Djtsi7bWO75vkKYkVxNRrJWY69pXLahIAkUN0mmt9cXNnaq2tpG59ctSY6P7ipJgBc7COJDRMRuwb2lYwtACNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-hook-form": {


### PR DESCRIPTION
### What does this PR do?
- Adds image cropping functionality to the user profile section.
- Users can now crop and adjust their profile pictures before saving.

### Why is this needed?
- Improves user experience by allowing them to upload properly framed images.
- Prevents the need for external tools to edit images before uploading.

### How was it implemented?
- Used  react-easy-crop image cropping.
- Updated the profile picture upload logic.
- Modified UI to include a cropping interface.

