### PR TITLE
chore: update GitHub Actions workflow to skip Dependabot PRs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   lint:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
update GitHub Actions workflow to skip Dependabot PRs Because Linting is not available for PRs from dependabot updates of dependencies and package-lock.json is not available