### PR TITLE
fix: Added Z-Index on Action Bar, Linked to (Issue #253)

### DIFF
--- a/frontend/src/components/user/blogpost/viewBlog/ViewBlogActionBar.tsx
+++ b/frontend/src/components/user/blogpost/viewBlog/ViewBlogActionBar.tsx
@@ -65,7 +65,7 @@ const ViewBlogActionBar: FC<ViewBlogActionBarProps> = ({
             className={`${isViewBlog
                     ? "sticky top-[75px] md:top-[73px]  border-b justify-end "
                     : " border-t justify-between mt-2"
-                } bg-white dark:bg-black flex flex-wrap sm:flex-nowrap items-center gap-2 sm:gap-3 py-2 px-2 sm:px-4 overflow-x-auto sm:overflow-visible`}
+                } bg-white dark:bg-black flex flex-wrap sm:flex-nowrap items-center gap-2 sm:gap-3 py-2 px-2 sm:px-4 overflow-x-auto sm:overflow-visible z-10`}
         >
             <div
                 onClick={() => navigate(-1)}


### PR DESCRIPTION
The code highlight was overlapping the action bar, added z-index on action bar to fix it.